### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Thanks to [jsdelivr](https://www.jsdelivr.com/) for hosting it.
 Current version can be found here: [https://www.jsdelivr.com/?query=bhwi](https://www.jsdelivr.com/?query=bhwi)
 
 ```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/bhwi/<version>/bhwi.min.css" type="text/css">
-<script src="https://cdn.jsdelivr.net/bhwi/<version>/bhwi.min.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/bloggerheaven/bhwi@<version>/dist/bhwi.min.css" type="text/css">
+<script src="https://cdn.jsdelivr.net/gh/bloggerheaven/bhwi@<version>/dist/bhwi.min.js"></script>
 <!-- latest version can be found in the release section -->
 ```
 
@@ -30,11 +30,11 @@ bower install bhwi
 ```html
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/bhwi/<version>/bhwi.min.css" type="text/css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/bloggerheaven/bhwi@<version>/dist/bhwi.min.css" type="text/css">
 
 <!-- Don't forget to load jQuery before bhwi -->
-<script src="https://cdn.jsdelivr.net/jquery/2.1.4/jquery.min.js"></script>
-<script src="https://cdn.jsdelivr.net/bhwi/<version>/bhwi.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jquery@2.1.4/dist/jquery.min.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/bloggerheaven/bhwi@<version>/dist/bhwi.min.js"></script>
 
 <!-- Insert a element with the id 'bhwi' -->
 <div id="bhwi"></div>


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/gh/bloggerheaven/bhwi.

Feel free to ping me if you have any questions regarding this change.